### PR TITLE
Changed the read buffer to be internal

### DIFF
--- a/include/boost/http/socket.hpp
+++ b/include/boost/http/socket.hpp
@@ -172,11 +172,8 @@ public:
 
     // ### START OF basic_server SPECIFIC FUNCTIONS ###
 
-    basic_socket(boost::asio::io_service &io_service,
-                 boost::asio::mutable_buffer inbuffer);
-
     template<class... Args>
-    basic_socket(boost::asio::mutable_buffer inbuffer, Args&&... args);
+    basic_socket(boost::asio::io_service&, Args&&... args);
 
     next_layer_type &next_layer();
     const next_layer_type &next_layer() const;
@@ -241,8 +238,7 @@ private:
     Socket channel;
     http::read_state istate;
 
-    // TODO: maybe replace by buffersequence to allow scatter-gather operations
-    asio::mutable_buffer buffer;
+    std::array<std::uint8_t, 256> read_buffer;
     std::size_t used_size = 0;
 
     /* pimpl is not used to avoid the extra level of indirection and the extra

--- a/src/example/spawn-chunked.cpp
+++ b/src/example/spawn-chunked.cpp
@@ -20,9 +20,7 @@ int main()
     auto work = [&acceptor](asio::yield_context yield) {
         while (true) {
             try {
-                char buffer[4];
-                http::socket socket(acceptor.get_io_service(),
-                                    asio::buffer(buffer));
+                http::socket socket(acceptor.get_io_service());
                 std::string method;
                 std::string path;
                 http::message message;

--- a/src/example/spawn-fileserver.cpp
+++ b/src/example/spawn-fileserver.cpp
@@ -25,9 +25,7 @@ int main(int argc, char *argv[])
     auto work = [&acceptor,file](asio::yield_context yield) {
         while (true) {
             try {
-                char buffer[4];
-                http::socket socket(acceptor.get_io_service(),
-                                   asio::buffer(buffer));
+                http::socket socket(acceptor.get_io_service());
                 std::string method;
                 std::string path;
                 http::message message;

--- a/src/example/spawn-fileserver2.cpp
+++ b/src/example/spawn-fileserver2.cpp
@@ -25,9 +25,7 @@ int main(int argc, char *argv[])
     auto work = [&acceptor,dir](asio::yield_context yield) {
         while (true) {
             try {
-                char buffer[4];
-                http::socket socket(acceptor.get_io_service(),
-                                   asio::buffer(buffer));
+                http::socket socket(acceptor.get_io_service());
                 std::string method;
                 std::string path;
                 http::message message;

--- a/src/example/spawn-with-runtime.cpp
+++ b/src/example/spawn-with-runtime.cpp
@@ -21,10 +21,8 @@ int main()
     auto work = [&acceptor](asio::yield_context yield) {
         while (true) {
             try {
-                char buffer[4];
                 http::server_socket_adaptor<http::socket>
-                underlying_socket(acceptor.get_io_service(),
-                                  asio::buffer(buffer));
+                underlying_socket(acceptor.get_io_service());
                 http::polymorphic_server_socket &socket = underlying_socket;
                 std::string method;
                 std::string path;

--- a/src/example/spawn-with-runtime2.cpp
+++ b/src/example/spawn-with-runtime2.cpp
@@ -21,9 +21,7 @@ int main()
     auto work = [&acceptor](asio::yield_context yield) {
         while (true) {
             try {
-                char buffer[4];
-                http::socket underlying_socket(acceptor.get_io_service(),
-                                               asio::buffer(buffer));
+                http::socket underlying_socket(acceptor.get_io_service());
                 http::server_socket_adaptor<
                     std::reference_wrapper<http::socket>>
                 adaptor(underlying_socket);

--- a/src/example/spawn.cpp
+++ b/src/example/spawn.cpp
@@ -20,9 +20,7 @@ int main()
     auto work = [&acceptor](asio::yield_context yield) {
         while (true) {
             try {
-                char buffer[4];
-                http::socket socket(acceptor.get_io_service(),
-                                   asio::buffer(buffer));
+                http::socket socket(acceptor.get_io_service());
                 std::string method;
                 std::string path;
                 http::message message;

--- a/src/tests/algorithm.cpp
+++ b/src/tests/algorithm.cpp
@@ -326,8 +326,7 @@ BOOST_AUTO_TEST_CASE(request_upgrade_desired) {
    don't try very hard to enforce the Socket concept. */
 BOOST_AUTO_TEST_CASE(write_without_reason_phrase) {
     boost::asio::io_service ios;
-    char buffer[1];
-    boost::http::socket socket(ios, boost::asio::buffer(buffer));
+    boost::http::socket socket(ios);
     boost::http::message m;
     async_write_response(socket, boost::http::status_code::ok, m,
                          [](boost::system::error_code) {});


### PR DESCRIPTION
The read buffer has been made internal to http::socket, partly for convenience, and partly to remove a potential source of error (e.g. the user could pass the same buffer to several sockets.)

The buffer size was 4 in the examples, but I have increased this to 256 to avoid too many calls to `async_read_some()` but the number 256 is an arbitrary choice.
