### PR TITLE
Update socket-inl.hpp

### DIFF
--- a/include/boost/http/socket-inl.hpp
+++ b/include/boost/http/socket-inl.hpp
@@ -209,7 +209,8 @@ basic_socket<Socket>
         + (implicit_content_length ? 0 : 1);
 
     // TODO (C++14): replace by dynarray
-    std::vector<asio::const_buffer> buffers(nbuffer_pieces);
+    std::vector<asio::const_buffer> buffers;
+    buffers.reserve(nbuffer_pieces);
 
     buffers.push_back((flags & HTTP_1_1) ? string_literal_buffer("HTTP/1.1 ")
                       : string_literal_buffer("HTTP/1.0 "));


### PR DESCRIPTION
Sure you want to construct the vector with `nbuffer_pieces` default-constructed asio buffers? If you only want to reserve space IMHO you must call `std::vector::reserve`.